### PR TITLE
fix 楽譜の更新に不要なコードがあったので削除

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -124,8 +124,7 @@ export default {
         this[`score${identifier}`] = score;
       };
     },
-    updateScore(score: Score, identifier: string) {
-      this[`score${identifier}`] = Object.assign({}, score);
+    updateScore() {
       if (this.scoreA && this.scoreA.loaded && this.scoreB && this.scoreB.loaded) {
         this.scoreDiff = new ScoreDiff(this.scoreA, this.scoreB);
         this.currentPartName = null;


### PR DESCRIPTION
楽譜の更新処理の部分で引数が定義されていますが、呼び出しで引数を指定していないため undefined になり、関数内で特に意味のある処理に利用されないようなので削除しました。